### PR TITLE
chore: gitignore Claude Code session state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# IndiQuant Frontend — environment configuration
+# Copy to `.env` and adjust for your local / deployed backends.
+
+# Backend tournament/submission/leaderboard API (FastAPI, routes mounted under /api/v1).
+# Include the /api/v1 suffix — the API client appends resource paths directly.
+VITE_API_BASE=http://localhost:8000/api/v1
+
+# Auth service (separate FastAPI service, routes mounted under /auth).
+# Do NOT include /auth — the client appends /auth/login, /auth/register, etc.
+VITE_AUTH_BASE=http://localhost:8001

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Claude Code session state — local tooling, not project source.
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,133 @@
+# CLAUDE.md — Frontend
+
+> Source of truth: Notion → System Architecture → Core Platform → **frontend**.
+> See the root `CLAUDE.md` for the platform-wide architecture and guardrails.
+
+## 1. Purpose and Strategic Role
+
+`Frontend` is the **user-facing presentation layer** of the IndiQuant platform. It
+gives participants and administrators a clear, constrained interface. It does not own
+data, enforce rules, or perform computations — it **renders authoritative state**
+supplied by `Backend` and guides users through permitted actions.
+
+Answers: *"How do humans interact with the system without violating its rules or
+assumptions?"*
+
+**The frontend must never become a second source of truth.** It reflects system
+state; it does not define it.
+
+## 2. Scope and Responsibilities
+
+- Presenting available tournaments and their status
+- Allowing authenticated users to download datasets
+- Allowing authenticated users to upload submissions
+- Displaying submission status and validation outcomes
+- Displaying leaderboards and reputation summaries
+- Providing administrative interfaces for authorized users
+
+**Must not**: compute scores, infer eligibility, or expose internal logic.
+
+## 3. User Types and Views
+
+1. **Participants** — view tournaments, download datasets, upload submissions, view
+   personal submission history, view public leaderboards
+2. **Administrators** — configure tournaments, manage dataset visibility, view system
+   status summaries
+
+The frontend relies **entirely** on backend authorization responses to determine what
+to display — it never makes its own authorization decisions (root `CLAUDE.md` §3:
+`FORECASTER`/`ADMIN` are distinct permission sets).
+
+## 4. Authentication Integration
+
+Integrates with `Auth` **indirectly via `Backend`**: initiates login flows, stores and
+presents tokens securely, attaches tokens to backend API requests, handles expiry and
+logout. **Never stores credentials or secrets directly.**
+
+## 5. Tournament Discovery and Status
+
+Displays name/description, dataset reference, submission window status, horizon
+information, current phase — **all read-only** from the frontend's perspective.
+
+## 6. Dataset Access Flow
+
+1. List datasets available to the user
+2. Display dataset metadata (version, time range)
+3. Provide a download mechanism via backend-controlled links
+
+Must not: cache datasets, modify dataset content, or reveal obfuscation mappings.
+Dataset access events are recorded by backend systems, not the frontend.
+
+## 7. Submission Upload Flow
+
+Select a file, attach required metadata (tournament, dataset version), upload to
+backend, display upload success/failure, display validation results once available.
+Must not pre-validate submissions beyond basic file presence/size checks — real
+validation is `Submission-Validator`'s job.
+
+## 8. Submission Status and Feedback
+
+Displays received / validated / rejected (with reasons) / scored — all status values
+sourced from backend state. **Must not infer or guess status transitions.**
+
+## 9. Leaderboards and Results Display
+
+Ranked lists, score values, relative positioning. Treats leaderboard data as
+**immutable once published** — must not recalculate or filter scores beyond
+presentation-level sorting.
+
+## 10. Reputation and History Views
+
+Displays reputation metrics and historical participation summaries as provided by
+backend. Must not compute reputation locally or merge data from multiple sources
+independently.
+
+## 11. Administrative Interfaces
+
+Tournament configuration forms, dataset visibility toggles, submission window
+controls — all executed via backend APIs and confirmed explicitly. No bulk or
+implicit actions.
+
+## 12. Error Handling and Messaging
+
+Backend errors displayed clearly but minimally; no internal stack traces or system
+details; user-facing messages must not reveal sensitive logic. Must not suppress or
+reinterpret backend errors.
+
+## 13. Determinism and State Management
+
+Backend state is authoritative; local UI state is ephemeral. **Refreshing the page
+must not change system state.**
+
+## 14. Security Considerations
+
+No secret storage, no privileged logic, protection against common client-side
+vulnerabilities, strict reliance on backend authorization. Assume all client-side
+state is untrusted.
+
+## 15. Performance Considerations
+
+Avoid unnecessary polling, respect backend rate limits, paginate large result sets.
+Performance optimizations must not compromise correctness.
+
+## 16. Explicit Non-Goals
+
+Must never: perform scoring or validation, execute trades, expose internal
+identifiers, infer/predict system outcomes, or act as a data processing layer.
+
+## 17. Why This Repository Is Separate
+
+Clear separation between UI and logic, easier iteration on UX, reduced security risk,
+independent scaling of presentation vs. computation.
+
+## 18. Engineering Notes for Claude Code
+
+- TypeScript/React per root `CLAUDE.md` §5 — keep this the only frontend surface;
+  don't introduce a second UI stack without a documented reason in `Docs/`.
+- Treat every value on screen as derived from a `Backend` response — if a feature
+  needs the frontend to compute, infer, or cache anything beyond display formatting,
+  stop and flag it (§16).
+- No obfuscation-mapping, real-identifier, or credential handling ever touches this
+  codebase (§6, §14) — that data must not reach the client at all.
+- There is no code path where a `FORECASTER` sees personalized allocation advice or a
+  return guarantee, per root `CLAUDE.md` §2 guardrail #3.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:dev": "vite build --mode development",
     "build:pages": "GITHUB_PAGES=true vite build",
     "preview": "vite preview",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/src/components/site/AppShell.tsx
+++ b/src/components/site/AppShell.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from "react";
+import { motion } from "framer-motion";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { LogOut } from "lucide-react";
+
+import { useAuth } from "@/lib/useAuth";
+
+// Lightweight shell for the authenticated tournament area. Mirrors the site's
+// dark aesthetic (grain + ambient light) but carries app navigation and the
+// signed-in identity / sign-out control instead of the marketing navbar.
+export function AppShell({ children }: { children: ReactNode }) {
+  const { authenticated, claims, signOut } = useAuth();
+  const navigate = useNavigate();
+
+  return (
+    <motion.div
+      id="top"
+      initial={{ opacity: 0, filter: "blur(6px)" }}
+      animate={{ opacity: 1, filter: "blur(0px)" }}
+      transition={{ duration: 0.7, ease: [0.22, 1, 0.36, 1] }}
+      className="relative min-h-screen bg-background text-foreground"
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-0 opacity-[0.025] mix-blend-overlay"
+        style={{
+          backgroundImage:
+            "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>\")",
+        }}
+      />
+      <header className="sticky top-0 z-50 border-b border-white/[0.06] bg-background/70 backdrop-blur-xl">
+        <div className="container-page flex h-16 items-center justify-between">
+          <div className="flex items-center gap-8">
+            <Link to="/" className="flex items-center gap-2.5 opacity-90 transition-opacity hover:opacity-100">
+              <Logo />
+              <span className="text-sm font-medium tracking-tight text-white">IndiQuant</span>
+            </Link>
+            <nav aria-label="Tournament" className="hidden items-center gap-6 md:flex">
+              <Link
+                to="/tournaments"
+                className="text-sm text-white/60 transition-colors hover:text-white [&.active]:text-white"
+              >
+                Tournaments
+              </Link>
+            </nav>
+          </div>
+
+          <div className="flex items-center gap-4">
+            {authenticated && claims?.email && (
+              <span className="hidden font-mono text-[11px] text-white/45 sm:inline">
+                {String(claims.email)}
+                {claims.role ? ` · ${String(claims.role).toLowerCase()}` : ""}
+              </span>
+            )}
+            {authenticated ? (
+              <button
+                onClick={() => {
+                  signOut();
+                  navigate({ to: "/sign-in" });
+                }}
+                className="inline-flex items-center gap-1.5 rounded-full border border-white/12 bg-white/[0.02] px-3 py-1.5 text-xs text-white/70 transition-colors hover:border-white/25 hover:text-white"
+              >
+                <LogOut size={13} strokeWidth={1.75} />
+                Sign out
+              </button>
+            ) : (
+              <Link
+                to="/sign-in"
+                className="inline-flex items-center rounded-full border border-white/12 bg-white/[0.02] px-3 py-1.5 text-xs text-white/70 transition-colors hover:border-white/25 hover:text-white"
+              >
+                Sign in
+              </Link>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="relative">{children}</main>
+    </motion.div>
+  );
+}
+
+function Logo() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden>
+      <circle cx="11" cy="11" r="10" stroke="url(#g3)" strokeWidth="1" />
+      <circle cx="11" cy="11" r="2" fill="#fff" />
+      <circle cx="11" cy="3" r="1" fill="#6C63FF" />
+      <circle cx="19" cy="11" r="1" fill="#00D4FF" />
+      <circle cx="11" cy="19" r="1" fill="#6C63FF" />
+      <circle cx="3" cy="11" r="1" fill="#00D4FF" />
+      <defs>
+        <linearGradient id="g3" x1="0" y1="0" x2="22" y2="22">
+          <stop stopColor="#6C63FF" />
+          <stop offset="1" stopColor="#00D4FF" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
+
+// Small status pill for a tournament's lifecycle state.
+export function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, string> = {
+    ANNOUNCED: "border-white/15 bg-white/[0.04] text-white/60",
+    SUBMISSION_OPEN: "border-emerald-400/30 bg-emerald-400/10 text-emerald-200",
+    LOCKED: "border-amber-400/30 bg-amber-400/10 text-amber-200",
+    SCORED: "border-sky-400/30 bg-sky-400/10 text-sky-200",
+    COMPLETE: "border-white/15 bg-white/[0.04] text-white/45",
+  };
+  const cls = map[status] ?? "border-white/15 bg-white/[0.04] text-white/60";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] ${cls}`}
+    >
+      {status.replace(/_/g, " ").toLowerCase()}
+    </span>
+  );
+}

--- a/src/components/site/Countdown.tsx
+++ b/src/components/site/Countdown.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+import { Clock } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// The platform runs on a 1-hour cadence: submissions LOCK at
+// `submission_close_at`, and scores land roughly one prediction horizon (~1h)
+// after the lock. This is a live countdown, not a weekly calendar view.
+export const SCORE_HORIZON_MS = 60 * 60 * 1000;
+
+function diffParts(ms: number) {
+  const clamped = Math.max(0, ms);
+  const totalSeconds = Math.floor(clamped / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return { days, hours, minutes, seconds };
+}
+
+function useNow(intervalMs = 1000): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+function Cell({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-col items-center">
+      <span className="font-mono text-2xl leading-none tabular-nums text-white sm:text-3xl">
+        {String(value).padStart(2, "0")}
+      </span>
+      <span className="mt-1 font-mono text-[9px] uppercase tracking-[0.2em] text-white/35">{label}</span>
+    </div>
+  );
+}
+
+// Large countdown block used on the tournament detail / submit hero.
+export function Countdown({
+  target,
+  className,
+  elapsedLabel = "Time elapsed",
+}: {
+  target: string | number | Date | null | undefined;
+  className?: string;
+  elapsedLabel?: string;
+}) {
+  const now = useNow();
+
+  if (target == null) {
+    return (
+      <div className={cn("font-mono text-sm text-white/40", className)}>Not scheduled</div>
+    );
+  }
+
+  const targetMs = new Date(target).getTime();
+  if (Number.isNaN(targetMs)) {
+    return <div className={cn("font-mono text-sm text-white/40", className)}>Not scheduled</div>;
+  }
+
+  const remaining = targetMs - now;
+
+  if (remaining <= 0) {
+    return (
+      <div className={cn("font-mono text-sm uppercase tracking-[0.2em] text-white/50", className)}>
+        {elapsedLabel}
+      </div>
+    );
+  }
+
+  const { days, hours, minutes, seconds } = diffParts(remaining);
+
+  return (
+    <div className={cn("flex items-center gap-4", className)}>
+      {days > 0 && (
+        <>
+          <Cell value={days} label="Days" />
+          <span className="font-mono text-2xl text-white/20">:</span>
+        </>
+      )}
+      <Cell value={hours} label="Hrs" />
+      <span className="font-mono text-2xl text-white/20">:</span>
+      <Cell value={minutes} label="Min" />
+      <span className="font-mono text-2xl text-white/20">:</span>
+      <Cell value={seconds} label="Sec" />
+    </div>
+  );
+}
+
+// Compact inline countdown chip for list rows.
+export function CountdownChip({
+  target,
+  prefix,
+  elapsedLabel = "closed",
+  className,
+}: {
+  target: string | number | Date | null | undefined;
+  prefix?: string;
+  elapsedLabel?: string;
+  className?: string;
+}) {
+  const now = useNow();
+
+  const base =
+    "inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 font-mono text-[11px] tabular-nums text-white/70";
+
+  if (target == null) {
+    return <span className={cn(base, "text-white/30", className)}>—</span>;
+  }
+
+  const targetMs = new Date(target).getTime();
+  if (Number.isNaN(targetMs)) {
+    return <span className={cn(base, "text-white/30", className)}>—</span>;
+  }
+
+  const remaining = targetMs - now;
+
+  if (remaining <= 0) {
+    return (
+      <span className={cn(base, "text-white/40", className)}>
+        <Clock size={11} strokeWidth={1.75} />
+        {elapsedLabel}
+      </span>
+    );
+  }
+
+  const { days, hours, minutes, seconds } = diffParts(remaining);
+  const text =
+    days > 0
+      ? `${days}d ${hours}h ${minutes}m`
+      : hours > 0
+        ? `${hours}h ${minutes}m ${seconds}s`
+        : `${minutes}m ${seconds}s`;
+
+  return (
+    <span className={cn(base, className)}>
+      <Clock size={11} strokeWidth={1.75} className="text-white/40" />
+      {prefix ? `${prefix} ` : ""}
+      {text}
+    </span>
+  );
+}

--- a/src/components/site/Countdown.tsx
+++ b/src/components/site/Countdown.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
 import { Clock } from "lucide-react";
 
+import { useNow } from "@/hooks/use-now";
 import { cn } from "@/lib/utils";
 
 // The platform runs on a 1-hour cadence: submissions LOCK at
@@ -16,15 +16,6 @@ function diffParts(ms: number) {
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
   return { days, hours, minutes, seconds };
-}
-
-function useNow(intervalMs = 1000): number {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), intervalMs);
-    return () => clearInterval(id);
-  }, [intervalMs]);
-  return now;
 }
 
 function Cell({ value, label }: { value: number; label: string }) {

--- a/src/components/site/Countdown.tsx
+++ b/src/components/site/Countdown.tsx
@@ -1,6 +1,7 @@
 import { Clock } from "lucide-react";
 
 import { useNow } from "@/hooks/use-now";
+import { parseServerTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 
 // The platform runs on a 1-hour cadence: submissions LOCK at
@@ -47,8 +48,10 @@ export function Countdown({
     );
   }
 
-  const targetMs = new Date(target).getTime();
-  if (Number.isNaN(targetMs)) {
+  // Backend timestamps are naive UTC; parseServerTime reads them as UTC
+  // rather than letting the browser assume local time (see lib/time.ts).
+  const targetMs = parseServerTime(target);
+  if (targetMs === null) {
     return <div className={cn("font-mono text-sm text-white/40", className)}>Not scheduled</div>;
   }
 
@@ -102,8 +105,10 @@ export function CountdownChip({
     return <span className={cn(base, "text-white/30", className)}>—</span>;
   }
 
-  const targetMs = new Date(target).getTime();
-  if (Number.isNaN(targetMs)) {
+  // Backend timestamps are naive UTC; parseServerTime reads them as UTC
+  // rather than letting the browser assume local time (see lib/time.ts).
+  const targetMs = parseServerTime(target);
+  if (targetMs === null) {
     return <span className={cn(base, "text-white/30", className)}>—</span>;
   }
 

--- a/src/components/site/Navbar.tsx
+++ b/src/components/site/Navbar.tsx
@@ -7,6 +7,7 @@ import { Button } from "./Button";
 const links = [
   { href: "/about", label: "About" },
   { href: "/contributors", label: "Contributors" },
+  { href: "/leaderboard", label: "Leaderboard" },
   { href: "/investors", label: "Investors" },
   { href: "/faq", label: "FAQ" },
 ];

--- a/src/components/site/RequireAuth.tsx
+++ b/src/components/site/RequireAuth.tsx
@@ -1,0 +1,32 @@
+import { useEffect, type ReactNode } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+
+import { useAuth } from "@/lib/useAuth";
+
+// Client-side auth gate for tournament pages. Redirects unauthenticated users
+// to /sign-in (preserving where they were headed). During SSR / pre-hydration
+// it renders a neutral loader so protected content never flashes.
+export function RequireAuth({ children, redirectTo }: { children: ReactNode; redirectTo?: string }) {
+  const { ready, authenticated } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (ready && !authenticated) {
+      navigate({
+        to: "/sign-in",
+        search: redirectTo ? { redirect: redirectTo } : undefined,
+      });
+    }
+  }, [ready, authenticated, navigate, redirectTo]);
+
+  if (!ready || !authenticated) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-white/40" aria-label="Loading" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/hooks/use-now.ts
+++ b/src/hooks/use-now.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+// A shared ticking clock. Lives here rather than inside Countdown.tsx so a page
+// that has to *gate* on a deadline (disabling the upload control once the
+// submission window closes) ticks off the same clock the visible countdown
+// does, instead of running a second interval that can disagree with what the
+// user is reading.
+export function useNow(intervalMs = 1000): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,218 @@
+// Typed API client for the IndiQuant Backend + Auth services.
+//
+// Base URLs come from env vars (see .env.example):
+//   VITE_API_BASE  -> Backend, includes /api/v1  (tournaments, submit, leaderboard)
+//   VITE_AUTH_BASE -> Auth service root          (/auth/login, /auth/register, ...)
+//
+// The fetch wrapper attaches the JWT bearer token from localStorage on every
+// Backend call. This platform is a Numerai-style tournament for Indian equities:
+// every instrument id crossing this boundary is an ANONYMIZED/obfuscated code —
+// never a real ticker or ISIN. No trading/broker surface exists here.
+
+import { getAccessToken, clearTokens } from "./auth";
+
+const RAW_API_BASE = import.meta.env.VITE_API_BASE as string | undefined;
+const RAW_AUTH_BASE = import.meta.env.VITE_AUTH_BASE as string | undefined;
+
+// Sensible localhost defaults so the app builds/runs without a .env present.
+export const API_BASE = (RAW_API_BASE ?? "http://localhost:8000/api/v1").replace(/\/$/, "");
+export const AUTH_BASE = (RAW_AUTH_BASE ?? "http://localhost:8001").replace(/\/$/, "");
+
+export class ApiError extends Error {
+  status: number;
+  detail: unknown;
+  constructor(status: number, detail: unknown, message?: string) {
+    super(message ?? `Request failed (${status})`);
+    this.name = "ApiError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+interface RequestOptions {
+  method?: string;
+  body?: BodyInit | null;
+  headers?: Record<string, string>;
+  auth?: boolean; // attach bearer token (default true)
+  json?: unknown; // convenience: JSON-serialize and set content-type
+}
+
+async function request<T>(baseUrl: string, path: string, opts: RequestOptions = {}): Promise<T> {
+  const { method = "GET", auth = true, json, headers = {} } = opts;
+  let body = opts.body;
+
+  const finalHeaders: Record<string, string> = { Accept: "application/json", ...headers };
+
+  if (json !== undefined) {
+    body = JSON.stringify(json);
+    finalHeaders["Content-Type"] = "application/json";
+  }
+
+  if (auth) {
+    const token = getAccessToken();
+    if (token) finalHeaders["Authorization"] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${baseUrl}${path}`, { method, headers: finalHeaders, body });
+
+  if (res.status === 401 && auth) {
+    // Token missing/expired/invalid — drop it so the UI can re-gate to sign-in.
+    clearTokens();
+  }
+
+  if (res.status === 204) return undefined as T;
+
+  const contentType = res.headers.get("content-type") ?? "";
+  const payload = contentType.includes("application/json")
+    ? await res.json().catch(() => null)
+    : await res.text().catch(() => null);
+
+  if (!res.ok) {
+    const detail =
+      payload && typeof payload === "object" && "detail" in payload
+        ? (payload as { detail: unknown }).detail
+        : payload;
+    throw new ApiError(res.status, detail, humanizeDetail(detail) ?? `Request failed (${res.status})`);
+  }
+
+  return payload as T;
+}
+
+function humanizeDetail(detail: unknown): string | undefined {
+  if (typeof detail === "string") return detail.replace(/_/g, " ");
+  if (detail && typeof detail === "object" && "errors" in detail) {
+    const errs = (detail as { errors: unknown }).errors;
+    if (Array.isArray(errs)) {
+      return errs
+        .map((e) =>
+          e && typeof e === "object"
+            ? Object.values(e as Record<string, unknown>).join(": ")
+            : String(e),
+        )
+        .join("; ");
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Types (mirror the Backend/Auth pydantic schemas)
+// ---------------------------------------------------------------------------
+
+export type TournamentStatus =
+  | "ANNOUNCED"
+  | "SUBMISSION_OPEN"
+  | "LOCKED"
+  | "SCORED"
+  | "COMPLETE";
+
+export interface Tournament {
+  id: number;
+  tournament_name: string;
+  dataset_version: string;
+  target_era: string;
+  status: TournamentStatus | string;
+  submission_open_at: string | null;
+  submission_close_at: string | null;
+  created_at: string;
+}
+
+export interface SubmissionResponse {
+  id: number;
+  tournament_id: number;
+  user_id: number;
+  file_hash: string;
+  row_count: number;
+  created_at: string;
+}
+
+// Participant-facing leaderboard row — composite score + rank only, never the
+// raw scoring components (per Scoring-Engine/CLAUDE.md §8a).
+export interface LeaderboardEntry {
+  submission_id: number;
+  user_id: number;
+  composite_score: number | null;
+  rank: number | null;
+  qualification_status: string | null;
+  computed_at: string;
+}
+
+export interface TokenPair {
+  access_token: string;
+  refresh_token: string;
+}
+
+export interface RegisterResponse {
+  id: number;
+  email: string;
+  role: string;
+  is_verified: boolean;
+  verification_token?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Auth service calls
+// ---------------------------------------------------------------------------
+
+export const authApi = {
+  login(email: string, password: string): Promise<TokenPair> {
+    return request<TokenPair>(AUTH_BASE, "/auth/login", {
+      method: "POST",
+      auth: false,
+      json: { email, password },
+    });
+  },
+  register(email: string, password: string): Promise<RegisterResponse> {
+    return request<RegisterResponse>(AUTH_BASE, "/auth/register", {
+      method: "POST",
+      auth: false,
+      json: { email, password },
+    });
+  },
+  refresh(refreshToken: string): Promise<TokenPair> {
+    return request<TokenPair>(AUTH_BASE, "/auth/refresh", {
+      method: "POST",
+      auth: false,
+      json: { refresh_token: refreshToken },
+    });
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Backend tournament / submission / leaderboard calls
+// ---------------------------------------------------------------------------
+
+export const tournamentsApi = {
+  list(): Promise<Tournament[]> {
+    return request<Tournament[]>(API_BASE, "/tournaments/");
+  },
+  listActive(): Promise<Tournament[]> {
+    return request<Tournament[]>(API_BASE, "/tournaments/active");
+  },
+  get(tournamentId: number): Promise<Tournament> {
+    return request<Tournament>(API_BASE, `/tournaments/${tournamentId}`);
+  },
+};
+
+export const submissionsApi = {
+  // Submits a prediction file (CSV with `id,score` columns of obfuscated codes).
+  // Backend takes tournament_id as a query param and the file as multipart `file`.
+  submit(tournamentId: number, file: File | Blob, filename = "predictions.csv"): Promise<SubmissionResponse> {
+    const form = new FormData();
+    form.append("file", file, filename);
+    return request<SubmissionResponse>(
+      API_BASE,
+      `/submit/?tournament_id=${encodeURIComponent(tournamentId)}`,
+      { method: "POST", body: form },
+    );
+  },
+};
+
+export const leaderboardApi = {
+  get(tournamentId: number): Promise<LeaderboardEntry[]> {
+    return request<LeaderboardEntry[]>(
+      API_BASE,
+      `/leaderboard/?tournament_id=${encodeURIComponent(tournamentId)}`,
+    );
+  },
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -111,6 +111,7 @@ export interface Tournament {
   tournament_name: string;
   dataset_version: string;
   target_era: string;
+  horizon_minutes: number;
   status: TournamentStatus | string;
   submission_open_at: string | null;
   submission_close_at: string | null;
@@ -135,6 +136,33 @@ export interface LeaderboardEntry {
   rank: number | null;
   qualification_status: string | null;
   computed_at: string;
+}
+
+// The UNAUTHENTICATED leaderboard row. Backend serves this from a separate
+// pydantic model (not a filtered internal one) precisely so nothing else can
+// leak into it; this interface mirrors that model exactly and must stay a
+// subset of it. `display_name` is null for accounts that predate handles —
+// render that as anonymous, never as an email or an id.
+export interface PublicLeaderboardEntry {
+  display_name: string | null;
+  composite_score: number | null;
+  rank: number | null;
+  last_scored_at: string;
+}
+
+// Config of the tournament currently accepting submissions. `submission_close_at`
+// here is the authoritative close instant: Tournament.submission_close_at is not
+// stamped until the round actually locks, so while a window is open this is the
+// only place the close time exists.
+export interface CurrentDataset {
+  tournament_id: number;
+  tournament_name: string;
+  dataset_version: string;
+  target_era: string;
+  id_universe: string[];
+  feature_columns: string[];
+  row_count: number;
+  submission_close_at: string | null;
 }
 
 export interface TokenPair {
@@ -214,5 +242,23 @@ export const leaderboardApi = {
       API_BASE,
       `/leaderboard/?tournament_id=${encodeURIComponent(tournamentId)}`,
     );
+  },
+  // Public board — deliberately `auth: false`. Sending a stale bearer token
+  // here would trip the 401 branch above and sign the visitor out of a page
+  // that never needed them signed in. 404 until the round reaches SCORED.
+  getPublic(tournamentId: number): Promise<PublicLeaderboardEntry[]> {
+    return request<PublicLeaderboardEntry[]>(
+      API_BASE,
+      `/leaderboard/public?tournament_id=${encodeURIComponent(tournamentId)}`,
+      { auth: false },
+    );
+  },
+};
+
+export const datasetsApi = {
+  // 404s when no tournament is open — "what should I submit for right now?"
+  // has no honest answer between windows.
+  current(): Promise<CurrentDataset> {
+    return request<CurrentDataset>(API_BASE, "/datasets/current");
   },
 };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,78 @@
+// Client-side auth state: JWT tokens live in localStorage (per Backend CORS
+// notes — bearer tokens in the Authorization header, not cookies). All access
+// is guarded for SSR, where `window`/`localStorage` do not exist.
+
+const ACCESS_TOKEN_KEY = "iq.access_token";
+const REFRESH_TOKEN_KEY = "iq.refresh_token";
+
+// Fired whenever tokens change so components can re-render auth state.
+export const AUTH_EVENT = "iq-auth-change";
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function getAccessToken(): string | null {
+  if (!isBrowser()) return null;
+  return window.localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function getRefreshToken(): string | null {
+  if (!isBrowser()) return null;
+  return window.localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+export function setTokens(accessToken: string, refreshToken?: string): void {
+  if (!isBrowser()) return;
+  window.localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+  if (refreshToken) window.localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+  window.dispatchEvent(new Event(AUTH_EVENT));
+}
+
+export function clearTokens(): void {
+  if (!isBrowser()) return;
+  window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+  window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+  window.dispatchEvent(new Event(AUTH_EVENT));
+}
+
+export function isAuthenticated(): boolean {
+  const token = getAccessToken();
+  if (!token) return false;
+  const claims = decodeJwt(token);
+  if (!claims) return true; // opaque token — assume valid until the API says otherwise
+  if (typeof claims.exp === "number" && claims.exp * 1000 < Date.now()) return false;
+  return true;
+}
+
+export interface JwtClaims {
+  sub?: string | number;
+  role?: string;
+  email?: string;
+  exp?: number;
+  type?: string;
+  [key: string]: unknown;
+}
+
+// Decodes the JWT payload for display only (role/email). NOT a security check —
+// the Backend verifies the signature; the client never trusts these for access.
+export function decodeJwt(token: string): JwtClaims | null {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+    const json =
+      typeof atob !== "undefined"
+        ? atob(padded)
+        : Buffer.from(padded, "base64").toString("binary");
+    return JSON.parse(json) as JwtClaims;
+  } catch {
+    return null;
+  }
+}
+
+export function getCurrentUserClaims(): JwtClaims | null {
+  const token = getAccessToken();
+  return token ? decodeJwt(token) : null;
+}

--- a/src/lib/leaderboard-view.test.ts
+++ b/src/lib/leaderboard-view.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { boardView } from "./leaderboard-view";
+
+const rows = [{ rank: 1 }, { rank: 2 }];
+
+// The confirmed defect: the route evaluated `if (watch.error)` before it
+// rendered `board.data`, so one failed 60s background poll replaced a
+// perfectly good published leaderboard with a red error panel.
+test("a failed background poll does not discard an already-rendered board", () => {
+  const view = boardView({ isLoading: false, isNotFound: false, hasError: true, rows });
+  assert.equal(view.kind, "rows");
+  assert.deepEqual(view.kind === "rows" && view.rows, rows);
+  assert.equal(view.kind === "rows" && view.stale, true);
+});
+
+test("a healthy board is not marked stale", () => {
+  const view = boardView({ isLoading: false, isNotFound: false, hasError: false, rows });
+  assert.equal(view.kind === "rows" && view.stale, false);
+});
+
+test("an error with nothing cached still surfaces as an error", () => {
+  assert.equal(
+    boardView({ isLoading: false, isNotFound: false, hasError: true, rows: undefined }).kind,
+    "error",
+  );
+  assert.equal(
+    boardView({ isLoading: false, isNotFound: false, hasError: true, rows: [] }).kind,
+    "error",
+  );
+});
+
+test("404 (round not scored yet) outranks the generic error panel", () => {
+  assert.equal(
+    boardView({ isLoading: false, isNotFound: true, hasError: true, rows: undefined }).kind,
+    "unpublished",
+  );
+});
+
+test("the first load shows the spinner", () => {
+  assert.equal(
+    boardView({ isLoading: true, isNotFound: false, hasError: false, rows: undefined }).kind,
+    "loading",
+  );
+});
+
+test("a round scored with no ranked submissions is empty, not an error", () => {
+  assert.equal(
+    boardView({ isLoading: false, isNotFound: false, hasError: false, rows: [] }).kind,
+    "empty",
+  );
+});

--- a/src/lib/leaderboard-view.ts
+++ b/src/lib/leaderboard-view.ts
@@ -1,0 +1,38 @@
+// Which of the public leaderboard's mutually exclusive states to render.
+//
+// Kept out of the route component (and free of any React/`import.meta.env`
+// dependency) so the precedence between "we have a published board" and "the
+// background poll just failed" is a pure function with its own test.
+//
+// The precedence that matters: an already-rendered board OUTRANKS a poll
+// error. The board is a snapshot pinned with `staleTime: Infinity` precisely
+// so it does not move under a reader; letting one transient 5xx on a 60s
+// background poll replace it with a red error panel would be a far bigger
+// disruption than the re-sort that pinning exists to prevent. React Query
+// keeps the data across the failure -- so we render it, and say it is stale
+// non-destructively instead.
+
+export type BoardView<Row> =
+  | { kind: "loading" }
+  /** Backend 404s the public route until the round reaches SCORED. */
+  | { kind: "unpublished" }
+  | { kind: "error" }
+  /** The round scored, but with no ranked submissions. */
+  | { kind: "empty" }
+  | { kind: "rows"; rows: Row[]; stale: boolean };
+
+export function boardView<Row>(input: {
+  isLoading: boolean;
+  isNotFound: boolean;
+  hasError: boolean;
+  rows: Row[] | undefined;
+}): BoardView<Row> {
+  const { isLoading, isNotFound, hasError, rows } = input;
+
+  // Anything we can still show beats anything we can only apologise for.
+  if (rows && rows.length > 0) return { kind: "rows", rows, stale: hasError };
+  if (isLoading) return { kind: "loading" };
+  if (isNotFound) return { kind: "unpublished" };
+  if (hasError) return { kind: "error" };
+  return { kind: "empty" };
+}

--- a/src/lib/time.test.ts
+++ b/src/lib/time.test.ts
@@ -1,0 +1,81 @@
+// Regression tests for the naive-UTC misparse.
+//
+// Backend serializes `datetime.now(timezone.utc).replace(tzinfo=None)` with NO
+// offset, and ECMAScript reads that offset-less form as LOCAL time. These run
+// under a deliberately non-UTC timezone (IST, +05:30 -- the platform's actual
+// audience) so a regression to plain `new Date(...)` fails here loudly instead
+// of passing on a UTC CI box and locking Indian contributors out in production.
+process.env.TZ = "Asia/Kolkata";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeServerTimestamp, parseServerTime, formatServerTime } from "./time";
+
+const IST_OFFSET_MS = 5.5 * 60 * 60 * 1000;
+
+test("the test process really is on a non-UTC timezone", () => {
+  // Guards the guard: on UTC every assertion below would pass trivially.
+  assert.equal(new Date("2026-08-21T10:00:00Z").getTimezoneOffset(), -330);
+});
+
+test("an offset-less Backend timestamp is read as UTC, not as local time", () => {
+  const raw = "2026-08-21T10:00:00";
+  assert.equal(parseServerTime(raw), Date.UTC(2026, 7, 21, 10, 0, 0));
+  // The bug, stated explicitly: the naive parse lands 5h30m earlier.
+  assert.equal(parseServerTime(raw)! - new Date(raw).getTime(), IST_OFFSET_MS);
+});
+
+test("microsecond precision from pydantic survives (truncated to ms)", () => {
+  assert.equal(parseServerTime("2026-08-20T08:00:00.123456"), Date.UTC(2026, 7, 20, 8, 0, 0, 123));
+});
+
+test("an explicit designator or offset is left alone", () => {
+  const utc = Date.UTC(2026, 7, 21, 10, 0, 0);
+  assert.equal(parseServerTime("2026-08-21T10:00:00Z"), utc);
+  assert.equal(parseServerTime("2026-08-21T15:30:00+05:30"), utc);
+  assert.equal(normalizeServerTimestamp("2026-08-21T10:00:00Z"), "2026-08-21T10:00:00Z");
+});
+
+test("absent and unparseable timestamps are null, never NaN", () => {
+  assert.equal(parseServerTime(null), null);
+  assert.equal(parseServerTime(undefined), null);
+  assert.equal(parseServerTime("not a date"), null);
+  assert.equal(parseServerTime(new Date("nope")), null);
+});
+
+test("Date and epoch-ms inputs pass through", () => {
+  const d = new Date(Date.UTC(2026, 7, 21, 10));
+  assert.equal(parseServerTime(d), d.getTime());
+  assert.equal(parseServerTime(d.getTime()), d.getTime());
+});
+
+// The defect the reviewer confirmed: the submission-window gate on
+// /tournaments/$tournamentId. `windowOpen` is
+//   status === "SUBMISSION_OPEN" && (closeMs === null || closeMs > now)
+// with closeMs from the round's close instant. This reproduces that arithmetic
+// at an instant 20 minutes BEFORE the close, in IST.
+test("the submission window gate stays open until the real close instant", () => {
+  const closeAt = "2026-08-21T10:00:00.000000"; // naive UTC, as Backend sends it
+  const twentyMinutesBefore = Date.UTC(2026, 7, 21, 9, 40, 0);
+
+  const closeMs = parseServerTime(closeAt);
+  assert.equal(closeMs !== null && closeMs > twentyMinutesBefore, true);
+
+  // Same instant, the old parse: the window reads as closed 5.5h too early.
+  const naiveCloseMs = new Date(closeAt).getTime();
+  assert.equal(naiveCloseMs > twentyMinutesBefore, false);
+});
+
+test("the gate closes once the real close instant passes", () => {
+  const closeMs = parseServerTime("2026-08-21T10:00:00.000000")!;
+  assert.equal(closeMs > Date.UTC(2026, 7, 21, 10, 0, 1), false);
+});
+
+test("formatServerTime renders the UTC instant in the viewer's own zone", () => {
+  // 10:00 UTC is 15:30 IST. The leaderboard's "Published ..." line used to
+  // show 10:00 to an IST reader.
+  const out = formatServerTime("2026-08-21T10:00:00", { hour: "2-digit", minute: "2-digit" });
+  assert.match(out!, /15:30|3:30/);
+  assert.equal(formatServerTime(null), null);
+});

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,60 @@
+// Parsing of timestamps that come off the IndiQuant Backend.
+//
+// Backend stamps every datetime with `backend_paths.utcnow()`, which is
+// `datetime.now(timezone.utc).replace(tzinfo=None)` -- naive-but-UTC by
+// convention (SQLite does not round-trip tzinfo, so the whole service compares
+// naive UTC to naive UTC). Pydantic therefore serializes it WITHOUT an offset:
+//
+//     "2026-08-20T08:00:00.123456"
+//
+// ECMAScript parses that offset-less date-time form as LOCAL time, so
+// `new Date(...)` on an IST browser lands 5h30m before the true instant. That
+// is not cosmetic: the submission window gate on the tournament page compares
+// the close instant to `Date.now()`, so an Indian contributor would see the
+// upload control disabled for essentially the whole window (and a contributor
+// west of UTC would be invited to upload into a window the server has closed).
+//
+// Every consumer of a Backend timestamp must go through this module rather than
+// calling `new Date(...)` directly, so there is exactly one place this
+// convention is encoded.
+
+// Date-time with no timezone designator and no offset: "2026-08-20T08:00:00",
+// "2026-08-20T08:00", "2026-08-20T08:00:00.123456", or the same with a space
+// separator. A trailing "Z" or "+05:30" means the server was explicit and we
+// leave the value completely alone.
+const OFFSETLESS_DATETIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/;
+
+/** Append the UTC designator to an offset-less Backend timestamp. */
+export function normalizeServerTimestamp(value: string): string {
+  const trimmed = value.trim();
+  return OFFSETLESS_DATETIME.test(trimmed) ? `${trimmed.replace(" ", "T")}Z` : trimmed;
+}
+
+/**
+ * Epoch milliseconds for a Backend timestamp, or null if it is absent or
+ * unparseable. Offset-less strings are read as UTC, never as local time.
+ */
+export function parseServerTime(value: string | number | Date | null | undefined): number | null {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return Number.isNaN(ms) ? null : ms;
+  }
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  const ms = new Date(normalizeServerTimestamp(value)).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+/**
+ * A Backend timestamp rendered in the viewer's own locale and timezone --
+ * correctly converted from UTC first. Returns null when there is nothing
+ * parseable to show, so callers decide their own fallback.
+ */
+export function formatServerTime(
+  value: string | number | Date | null | undefined,
+  options?: Intl.DateTimeFormatOptions,
+): string | null {
+  const ms = parseServerTime(value);
+  if (ms === null) return null;
+  return new Date(ms).toLocaleString(undefined, options);
+}

--- a/src/lib/useAuth.ts
+++ b/src/lib/useAuth.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+import {
+  AUTH_EVENT,
+  clearTokens,
+  getCurrentUserClaims,
+  isAuthenticated,
+  type JwtClaims,
+} from "./auth";
+
+export interface AuthState {
+  ready: boolean; // hydrated on the client (false during SSR / first paint)
+  authenticated: boolean;
+  claims: JwtClaims | null;
+  signOut: () => void;
+}
+
+// Client-side auth state. During SSR and the first paint `ready` is false and
+// `authenticated` is false, so gated UI shows a neutral placeholder rather than
+// flashing protected content before hydration.
+export function useAuth(): AuthState {
+  const [state, setState] = useState<{ authenticated: boolean; claims: JwtClaims | null; ready: boolean }>({
+    authenticated: false,
+    claims: null,
+    ready: false,
+  });
+
+  useEffect(() => {
+    const sync = () =>
+      setState({ authenticated: isAuthenticated(), claims: getCurrentUserClaims(), ready: true });
+    sync();
+    window.addEventListener(AUTH_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(AUTH_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+
+  return { ...state, signOut: () => clearTokens() };
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SignUpRouteImport } from './routes/sign-up'
 import { Route as SignInRouteImport } from './routes/sign-in'
+import { Route as LeaderboardRouteImport } from './routes/leaderboard'
 import { Route as InvestorsRouteImport } from './routes/investors'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as FaqRouteImport } from './routes/faq'
@@ -18,6 +19,8 @@ import { Route as ContributorsRouteImport } from './routes/contributors'
 import { Route as ContactRouteImport } from './routes/contact'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as TournamentsIndexRouteImport } from './routes/tournaments/index'
+import { Route as TournamentsTournamentIdRouteImport } from './routes/tournaments/$tournamentId'
 
 const SignUpRoute = SignUpRouteImport.update({
   id: '/sign-up',
@@ -27,6 +30,11 @@ const SignUpRoute = SignUpRouteImport.update({
 const SignInRoute = SignInRouteImport.update({
   id: '/sign-in',
   path: '/sign-in',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LeaderboardRoute = LeaderboardRouteImport.update({
+  id: '/leaderboard',
+  path: '/leaderboard',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InvestorsRoute = InvestorsRouteImport.update({
@@ -64,6 +72,16 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TournamentsIndexRoute = TournamentsIndexRouteImport.update({
+  id: '/tournaments/',
+  path: '/tournaments/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TournamentsTournamentIdRoute = TournamentsTournamentIdRouteImport.update({
+  id: '/tournaments/$tournamentId',
+  path: '/tournaments/$tournamentId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -73,8 +91,11 @@ export interface FileRoutesByFullPath {
   '/faq': typeof FaqRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/investors': typeof InvestorsRoute
+  '/leaderboard': typeof LeaderboardRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/tournaments/$tournamentId': typeof TournamentsTournamentIdRoute
+  '/tournaments/': typeof TournamentsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -84,8 +105,11 @@ export interface FileRoutesByTo {
   '/faq': typeof FaqRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/investors': typeof InvestorsRoute
+  '/leaderboard': typeof LeaderboardRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/tournaments/$tournamentId': typeof TournamentsTournamentIdRoute
+  '/tournaments': typeof TournamentsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -96,8 +120,11 @@ export interface FileRoutesById {
   '/faq': typeof FaqRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/investors': typeof InvestorsRoute
+  '/leaderboard': typeof LeaderboardRoute
   '/sign-in': typeof SignInRoute
   '/sign-up': typeof SignUpRoute
+  '/tournaments/$tournamentId': typeof TournamentsTournamentIdRoute
+  '/tournaments/': typeof TournamentsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -109,8 +136,11 @@ export interface FileRouteTypes {
     | '/faq'
     | '/forgot-password'
     | '/investors'
+    | '/leaderboard'
     | '/sign-in'
     | '/sign-up'
+    | '/tournaments/$tournamentId'
+    | '/tournaments/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -120,8 +150,11 @@ export interface FileRouteTypes {
     | '/faq'
     | '/forgot-password'
     | '/investors'
+    | '/leaderboard'
     | '/sign-in'
     | '/sign-up'
+    | '/tournaments/$tournamentId'
+    | '/tournaments'
   id:
     | '__root__'
     | '/'
@@ -131,8 +164,11 @@ export interface FileRouteTypes {
     | '/faq'
     | '/forgot-password'
     | '/investors'
+    | '/leaderboard'
     | '/sign-in'
     | '/sign-up'
+    | '/tournaments/$tournamentId'
+    | '/tournaments/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -143,8 +179,11 @@ export interface RootRouteChildren {
   FaqRoute: typeof FaqRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   InvestorsRoute: typeof InvestorsRoute
+  LeaderboardRoute: typeof LeaderboardRoute
   SignInRoute: typeof SignInRoute
   SignUpRoute: typeof SignUpRoute
+  TournamentsTournamentIdRoute: typeof TournamentsTournamentIdRoute
+  TournamentsIndexRoute: typeof TournamentsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -161,6 +200,13 @@ declare module '@tanstack/react-router' {
       path: '/sign-in'
       fullPath: '/sign-in'
       preLoaderRoute: typeof SignInRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/leaderboard': {
+      id: '/leaderboard'
+      path: '/leaderboard'
+      fullPath: '/leaderboard'
+      preLoaderRoute: typeof LeaderboardRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/investors': {
@@ -212,6 +258,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/tournaments/': {
+      id: '/tournaments/'
+      path: '/tournaments'
+      fullPath: '/tournaments/'
+      preLoaderRoute: typeof TournamentsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tournaments/$tournamentId': {
+      id: '/tournaments/$tournamentId'
+      path: '/tournaments/$tournamentId'
+      fullPath: '/tournaments/$tournamentId'
+      preLoaderRoute: typeof TournamentsTournamentIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -223,8 +283,11 @@ const rootRouteChildren: RootRouteChildren = {
   FaqRoute: FaqRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,
   InvestorsRoute: InvestorsRoute,
+  LeaderboardRoute: LeaderboardRoute,
   SignInRoute: SignInRoute,
   SignUpRoute: SignUpRoute,
+  TournamentsTournamentIdRoute: TournamentsTournamentIdRoute,
+  TournamentsIndexRoute: TournamentsIndexRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/leaderboard.tsx
+++ b/src/routes/leaderboard.tsx
@@ -1,0 +1,279 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useState, type FormEvent } from "react";
+import { Loader2, Medal, Trophy } from "lucide-react";
+
+import { PageShell } from "@/components/site/PageShell";
+import { Button } from "@/components/site/Button";
+import { Input } from "@/components/site/Field";
+import {
+  ApiError,
+  leaderboardApi,
+  tournamentsApi,
+  type PublicLeaderboardEntry,
+  type Tournament,
+} from "@/lib/api";
+import { useAuth } from "@/lib/useAuth";
+
+interface LeaderboardSearch {
+  tournament?: number;
+}
+
+export const Route = createFileRoute("/leaderboard")({
+  validateSearch: (search: Record<string, unknown>): LeaderboardSearch => {
+    const raw = search.tournament;
+    const n = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
+    return Number.isInteger(n) && n > 0 ? { tournament: n } : {};
+  },
+  head: () => ({
+    meta: [
+      { title: "Leaderboard — IndiQuant" },
+      {
+        name: "description",
+        content:
+          "Published results for IndiQuant research rounds: contributor handles, composite scores and ranks.",
+      },
+      { property: "og:title", content: "Leaderboard — IndiQuant" },
+      { property: "og:url", content: "/leaderboard" },
+    ],
+    links: [{ rel: "canonical", href: "/leaderboard" }],
+  }),
+  component: LeaderboardPage,
+});
+
+// This is the one page on the platform served without a token — it is
+// deliberately NOT wrapped in RequireAuth. Everything it renders comes from
+// Backend's public leaderboard model, which carries a handle, a composite
+// score, a rank and a scoring timestamp and nothing else. Component scores,
+// selection thresholds and account identity stay server-side (root
+// CLAUDE.md §2 guardrail #5).
+function LeaderboardPage() {
+  const { tournament } = Route.useSearch();
+
+  return (
+    <PageShell>
+      <section className="container-page pt-36 pb-28 sm:pt-44 sm:pb-36">
+        <header className="max-w-2xl">
+          <div className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.2em] text-white/45">
+            <Trophy size={13} strokeWidth={1.75} />
+            Public results
+          </div>
+          <h1 className="mt-4 font-display text-4xl leading-[1.05] tracking-tight text-white sm:text-5xl">
+            Leaderboard
+          </h1>
+          <p className="mt-4 text-sm leading-relaxed text-white/55">
+            Published standings for a scored research round. A round appears here only once its
+            batch has been scored — there is no partial or provisional view.
+          </p>
+        </header>
+
+        <RoundSelector selected={tournament} />
+
+        {tournament == null ? (
+          <p className="mt-10 rounded-xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center text-sm text-white/45">
+            Choose a round to see its published standings.
+          </p>
+        ) : (
+          <Board tournamentId={tournament} />
+        )}
+      </section>
+    </PageShell>
+  );
+}
+
+// Backend has no unauthenticated route that enumerates tournaments, so an
+// anonymous visitor reaches a board by round number (from the round's own
+// page or its announcement). Signed-in contributors get the real picker.
+function RoundSelector({ selected }: { selected?: number }) {
+  const navigate = useNavigate();
+  const { ready, authenticated } = useAuth();
+
+  const { data } = useQuery({
+    queryKey: ["tournaments"],
+    queryFn: () => tournamentsApi.list(),
+    enabled: ready && authenticated,
+  });
+
+  const published = (data ?? []).filter(
+    (t: Tournament) => t.status === "SCORED" || t.status === "COMPLETE",
+  );
+
+  if (published.length > 0) {
+    return (
+      <div className="mt-10 flex flex-wrap gap-2">
+        {published.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => navigate({ to: "/leaderboard", search: { tournament: t.id } })}
+            className={`rounded-full border px-4 py-1.5 font-mono text-[11px] transition-colors ${
+              t.id === selected
+                ? "border-white/30 bg-white/[0.06] text-white"
+                : "border-white/10 bg-white/[0.02] text-white/55 hover:border-white/25 hover:text-white"
+            }`}
+          >
+            {t.tournament_name}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return <RoundNumberForm selected={selected} />;
+}
+
+function RoundNumberForm({ selected }: { selected?: number }) {
+  const navigate = useNavigate();
+  const [value, setValue] = useState(selected ? String(selected) : "");
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const n = Number(value);
+    if (!Number.isInteger(n) || n <= 0) return;
+    navigate({ to: "/leaderboard", search: { tournament: n } });
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="mt-10 flex max-w-sm items-end gap-3">
+      <div className="flex-1">
+        <label
+          htmlFor="round"
+          className="mb-2 block font-mono text-[10px] uppercase tracking-[0.22em] text-white/45"
+        >
+          Round
+        </label>
+        <Input
+          id="round"
+          name="round"
+          inputMode="numeric"
+          placeholder="e.g. 12"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </div>
+      <Button type="submit" size="md" variant="ghost">
+        View
+      </Button>
+    </form>
+  );
+}
+
+// The published watermark: the most recent scoring timestamp on the board.
+// It is the React Query cache key for the rendered snapshot, which is then
+// pinned with `staleTime: Infinity`. That is the point — a poll returning the
+// same watermark cannot re-render or re-sort the table, so contributors never
+// watch a ranking shuffle under them between batches. Only a genuinely new
+// (or re-run) scoring batch advances the watermark and swaps the snapshot.
+function publishedWatermark(rows: PublicLeaderboardEntry[] | undefined): string | null {
+  if (!rows || rows.length === 0) return null;
+  return rows.reduce(
+    (latest, r) => (r.last_scored_at > latest ? r.last_scored_at : latest),
+    rows[0].last_scored_at,
+  );
+}
+
+function Board({ tournamentId }: { tournamentId: number }) {
+  // The watch query. Backend 404s this route until the round reaches SCORED,
+  // so there is nothing to render mid-computation; once scored, this exists
+  // only to notice that the watermark moved.
+  const watch = useQuery({
+    queryKey: ["leaderboard", "public", tournamentId, "watch"],
+    queryFn: () => leaderboardApi.getPublic(tournamentId),
+    refetchInterval: 60_000, // the platform scores hourly; a minute is plenty
+    retry: (failureCount, error) =>
+      !(error instanceof ApiError && error.status === 404) && failureCount < 2,
+  });
+
+  const watermark = publishedWatermark(watch.data);
+
+  // The rendered snapshot, keyed on the watermark. `initialData` hands it the
+  // rows the watch query already fetched, so a new batch costs no extra
+  // request; `staleTime: Infinity` then freezes that snapshot for its key.
+  const board = useQuery({
+    queryKey: ["leaderboard", "public", tournamentId, watermark],
+    queryFn: () => leaderboardApi.getPublic(tournamentId),
+    enabled: watermark !== null,
+    initialData: watermark !== null ? watch.data : undefined,
+    staleTime: Infinity,
+    placeholderData: keepPreviousData,
+  });
+
+  if (watch.isLoading) {
+    return (
+      <div className="mt-10 flex items-center gap-2 py-16 text-sm text-white/40">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading standings…
+      </div>
+    );
+  }
+
+  if (watch.error instanceof ApiError && watch.error.status === 404) {
+    return (
+      <p className="mt-10 rounded-xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center text-sm text-white/45">
+        No published results for round {tournamentId} yet.
+      </p>
+    );
+  }
+
+  if (watch.error) {
+    return (
+      <p className="mt-10 rounded-xl border border-[#ff8a8a]/25 bg-[#ff8a8a]/[0.06] px-5 py-4 text-sm text-[#ffb4b4]">
+        {watch.error instanceof ApiError ? watch.error.message : "Failed to load the leaderboard."}
+      </p>
+    );
+  }
+
+  const rows = board.data;
+  if (!rows || rows.length === 0) {
+    return (
+      <p className="mt-10 rounded-xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center text-sm text-white/45">
+        This round scored with no ranked submissions.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="mt-10 overflow-x-auto rounded-2xl border border-white/[0.07] bg-white/[0.015]">
+        <table className="w-full min-w-[420px] text-left">
+          <thead>
+            <tr className="border-b border-white/[0.07] font-mono text-[10px] uppercase tracking-[0.18em] text-white/35">
+              <th className="px-6 py-4 font-normal">Rank</th>
+              <th className="px-6 py-4 font-normal">Contributor</th>
+              <th className="px-6 py-4 text-right font-normal">Composite score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {/* Rendered in the order Backend returned. The frontend never
+                re-ranks or re-scores a published board (Frontend/CLAUDE.md §9). */}
+            {rows.map((row, i) => (
+              <tr
+                key={`${row.rank ?? "unranked"}-${row.display_name ?? "anonymous"}-${i}`}
+                className="border-b border-white/[0.04] last:border-b-0"
+              >
+                <td className="px-6 py-4 font-mono text-sm tabular-nums text-white/70">
+                  <span className="inline-flex items-center gap-2">
+                    {row.rank != null && row.rank <= 3 && (
+                      <Medal size={13} strokeWidth={1.75} className="text-white/50" />
+                    )}
+                    {row.rank ?? "—"}
+                  </span>
+                </td>
+                <td className="px-6 py-4 text-sm text-white">
+                  {row.display_name ?? <span className="text-white/40">anonymous</span>}
+                </td>
+                <td className="px-6 py-4 text-right font-mono text-sm tabular-nums text-white/75">
+                  {row.composite_score != null ? row.composite_score.toFixed(4) : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {watermark && (
+        <p className="mt-4 font-mono text-[11px] text-white/30">
+          Published {new Date(watermark).toLocaleString()}
+        </p>
+      )}
+    </>
+  );
+}

--- a/src/routes/leaderboard.tsx
+++ b/src/routes/leaderboard.tsx
@@ -13,6 +13,8 @@ import {
   type PublicLeaderboardEntry,
   type Tournament,
 } from "@/lib/api";
+import { boardView } from "@/lib/leaderboard-view";
+import { formatServerTime } from "@/lib/time";
 import { useAuth } from "@/lib/useAuth";
 
 interface LeaderboardSearch {
@@ -197,7 +199,19 @@ function Board({ tournamentId }: { tournamentId: number }) {
     placeholderData: keepPreviousData,
   });
 
-  if (watch.isLoading) {
+  // A poll failure must never take a published board off the screen: React
+  // Query still holds `board.data`, and a reader losing the whole table to a
+  // transient 5xx is a worse disruption than the re-sort this page pins its
+  // snapshot to avoid. boardView encodes that precedence; the failure is
+  // reported as a staleness note under the table instead.
+  const view = boardView({
+    isLoading: watch.isLoading,
+    isNotFound: watch.error instanceof ApiError && watch.error.status === 404,
+    hasError: watch.error != null,
+    rows: board.data,
+  });
+
+  if (view.kind === "loading") {
     return (
       <div className="mt-10 flex items-center gap-2 py-16 text-sm text-white/40">
         <Loader2 className="h-4 w-4 animate-spin" /> Loading standings…
@@ -205,7 +219,7 @@ function Board({ tournamentId }: { tournamentId: number }) {
     );
   }
 
-  if (watch.error instanceof ApiError && watch.error.status === 404) {
+  if (view.kind === "unpublished") {
     return (
       <p className="mt-10 rounded-xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center text-sm text-white/45">
         No published results for round {tournamentId} yet.
@@ -213,7 +227,7 @@ function Board({ tournamentId }: { tournamentId: number }) {
     );
   }
 
-  if (watch.error) {
+  if (view.kind === "error") {
     return (
       <p className="mt-10 rounded-xl border border-[#ff8a8a]/25 bg-[#ff8a8a]/[0.06] px-5 py-4 text-sm text-[#ffb4b4]">
         {watch.error instanceof ApiError ? watch.error.message : "Failed to load the leaderboard."}
@@ -221,14 +235,15 @@ function Board({ tournamentId }: { tournamentId: number }) {
     );
   }
 
-  const rows = board.data;
-  if (!rows || rows.length === 0) {
+  if (view.kind === "empty") {
     return (
       <p className="mt-10 rounded-xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center text-sm text-white/45">
         This round scored with no ranked submissions.
       </p>
     );
   }
+
+  const rows = view.rows;
 
   return (
     <>
@@ -269,9 +284,17 @@ function Board({ tournamentId }: { tournamentId: number }) {
         </table>
       </div>
 
-      {watermark && (
+      {/* formatServerTime converts Backend's offset-less naive-UTC stamp
+          before rendering it in the reader's own timezone; `new Date(...)`
+          here silently showed a time shifted by the viewer's UTC offset. */}
+      {(watermark || view.stale) && (
         <p className="mt-4 font-mono text-[11px] text-white/30">
-          Published {new Date(watermark).toLocaleString()}
+          {watermark && <>Published {formatServerTime(watermark) ?? watermark}</>}
+          {view.stale && (
+            <span className={watermark ? "ml-2 text-white/25" : "text-white/25"}>
+              {watermark ? "· " : ""}live updates paused — could not reach the server
+            </span>
+          )}
         </p>
       )}
     </>

--- a/src/routes/sign-in.tsx
+++ b/src/routes/sign-in.tsx
@@ -1,11 +1,20 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useState, type FormEvent } from "react";
 
 import { Button } from "@/components/site/Button";
 import { Field, Input } from "@/components/site/Field";
 import { AuthShell } from "@/components/site/AuthShell";
+import { authApi, ApiError } from "@/lib/api";
+import { setTokens } from "@/lib/auth";
+
+interface SignInSearch {
+  redirect?: string;
+}
 
 export const Route = createFileRoute("/sign-in")({
+  validateSearch: (search: Record<string, unknown>): SignInSearch => ({
+    redirect: typeof search.redirect === "string" ? search.redirect : undefined,
+  }),
   head: () => ({
     meta: [
       { title: "Sign In — IndiQuant" },
@@ -20,16 +29,42 @@ export const Route = createFileRoute("/sign-in")({
 });
 
 function SignInPage() {
+  const navigate = useNavigate();
+  const { redirect } = Route.useSearch();
   const [errors, setErrors] = useState<Record<string, string>>({});
-  function onSubmit(e: FormEvent<HTMLFormElement>) {
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    setFormError(null);
     const f = new FormData(e.currentTarget);
     const next: Record<string, string> = {};
     const email = String(f.get("email") ?? "").trim();
+    const password = String(f.get("password") ?? "");
     if (!/^\S+@\S+\.\S+$/.test(email)) next.email = "Enter a valid email.";
-    if (!String(f.get("password") ?? "")) next.password = "Password is required.";
+    if (!password) next.password = "Password is required.";
     setErrors(next);
+    if (Object.keys(next).length > 0) return;
+
+    setSubmitting(true);
+    try {
+      const tokens = await authApi.login(email, password);
+      setTokens(tokens.access_token, tokens.refresh_token);
+      navigate({ to: redirect ?? "/tournaments" });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) {
+        setFormError("Invalid email or password.");
+      } else if (err instanceof ApiError) {
+        setFormError(err.message);
+      } else {
+        setFormError("Could not reach the server. Check your connection and try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
   }
+
   return (
     <AuthShell
       eyebrow="Welcome back"
@@ -46,6 +81,11 @@ function SignInPage() {
       }
     >
       <form onSubmit={onSubmit} noValidate className="space-y-6">
+        {formError && (
+          <p className="rounded-lg border border-[#ff8a8a]/30 bg-[#ff8a8a]/10 px-3 py-2 text-xs text-[#ff8a8a]">
+            {formError}
+          </p>
+        )}
         <Field label="Email" htmlFor="email" error={errors.email}>
           <Input id="email" name="email" type="email" autoComplete="email" placeholder="you@domain.com" />
         </Field>
@@ -61,8 +101,8 @@ function SignInPage() {
         >
           <Input id="password" name="password" type="password" autoComplete="current-password" placeholder="••••••••" />
         </Field>
-        <Button type="submit" withArrow className="w-full">
-          Sign in
+        <Button type="submit" withArrow className="w-full" disabled={submitting}>
+          {submitting ? "Signing in…" : "Sign in"}
         </Button>
       </form>
     </AuthShell>

--- a/src/routes/sign-up.tsx
+++ b/src/routes/sign-up.tsx
@@ -1,9 +1,11 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useState, type FormEvent } from "react";
 
 import { Button } from "@/components/site/Button";
 import { Field, Input } from "@/components/site/Field";
 import { AuthShell } from "@/components/site/AuthShell";
+import { authApi, ApiError } from "@/lib/api";
+import { setTokens } from "@/lib/auth";
 
 export const Route = createFileRoute("/sign-up")({
   head: () => ({
@@ -23,9 +25,14 @@ export const Route = createFileRoute("/sign-up")({
 });
 
 function SignUpPage() {
+  const navigate = useNavigate();
   const [errors, setErrors] = useState<Record<string, string>>({});
-  function onSubmit(e: FormEvent<HTMLFormElement>) {
+  const [formError, setFormError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    setFormError(null);
     const f = new FormData(e.currentTarget);
     const next: Record<string, string> = {};
     if (!String(f.get("name") ?? "").trim()) next.name = "Please enter your name.";
@@ -34,7 +41,29 @@ function SignUpPage() {
     const pw = String(f.get("password") ?? "");
     if (pw.length < 8) next.password = "At least 8 characters.";
     setErrors(next);
+    if (Object.keys(next).length > 0) return;
+
+    setSubmitting(true);
+    try {
+      // Register, then log in to obtain a token pair (registration returns the
+      // user record, not tokens). The Auth service assigns the FORECASTER role.
+      await authApi.register(email, pw);
+      const tokens = await authApi.login(email, pw);
+      setTokens(tokens.access_token, tokens.refresh_token);
+      navigate({ to: "/tournaments" });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setFormError("An account with this email already exists. Try signing in.");
+      } else if (err instanceof ApiError) {
+        setFormError(err.message);
+      } else {
+        setFormError("Could not reach the server. Check your connection and try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
   }
+
   return (
     <AuthShell
       eyebrow="Begin"
@@ -51,6 +80,11 @@ function SignUpPage() {
       }
     >
       <form onSubmit={onSubmit} noValidate className="space-y-6">
+        {formError && (
+          <p className="rounded-lg border border-[#ff8a8a]/30 bg-[#ff8a8a]/10 px-3 py-2 text-xs text-[#ff8a8a]">
+            {formError}
+          </p>
+        )}
         <Field label="Name" htmlFor="name" error={errors.name}>
           <Input id="name" name="name" autoComplete="name" placeholder="Your full name" />
         </Field>
@@ -60,8 +94,8 @@ function SignUpPage() {
         <Field label="Password" htmlFor="password" hint="8+ characters" error={errors.password}>
           <Input id="password" name="password" type="password" autoComplete="new-password" placeholder="••••••••" />
         </Field>
-        <Button type="submit" withArrow className="w-full">
-          Create account
+        <Button type="submit" withArrow className="w-full" disabled={submitting}>
+          {submitting ? "Creating account…" : "Create account"}
         </Button>
         <p className="text-center text-xs text-white/40">
           By continuing you agree to our terms and privacy policy.

--- a/src/routes/tournaments/$tournamentId.tsx
+++ b/src/routes/tournaments/$tournamentId.tsx
@@ -1,0 +1,372 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef, useState, type FormEvent, type ReactNode } from "react";
+import { ArrowLeft, CheckCircle2, Loader2, Upload } from "lucide-react";
+
+import { AppShell, StatusBadge } from "@/components/site/AppShell";
+import { RequireAuth } from "@/components/site/RequireAuth";
+import { Countdown } from "@/components/site/Countdown";
+import { Button } from "@/components/site/Button";
+import { useNow } from "@/hooks/use-now";
+import {
+  ApiError,
+  datasetsApi,
+  submissionsApi,
+  tournamentsApi,
+  type CurrentDataset,
+  type SubmissionResponse,
+  type Tournament,
+} from "@/lib/api";
+
+export const Route = createFileRoute("/tournaments/$tournamentId")({
+  head: () => ({
+    meta: [
+      { title: "Round — IndiQuant" },
+      { name: "description", content: "Tournament round detail and prediction upload." },
+      { name: "robots", content: "noindex" },
+    ],
+  }),
+  component: TournamentDetailPage,
+});
+
+function TournamentDetailPage() {
+  const { tournamentId } = Route.useParams();
+
+  return (
+    <AppShell>
+      <RequireAuth redirectTo={`/tournaments/${tournamentId}`}>
+        <TournamentDetail tournamentId={Number(tournamentId)} />
+      </RequireAuth>
+    </AppShell>
+  );
+}
+
+function TournamentDetail({ tournamentId }: { tournamentId: number }) {
+  const {
+    data: tournament,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["tournament", tournamentId],
+    queryFn: () => tournamentsApi.get(tournamentId),
+    enabled: Number.isInteger(tournamentId),
+    refetchInterval: 60_000, // status moves on the hour: OPEN → LOCKED → SCORED
+  });
+
+  // Only the currently-open round has a dataset config to fetch, and the route
+  // 404s between windows — so no retry, and an absent result is a normal state.
+  const { data: dataset } = useQuery({
+    queryKey: ["dataset", "current"],
+    queryFn: () => datasetsApi.current(),
+    enabled: tournament?.status === "SUBMISSION_OPEN",
+    retry: false,
+  });
+
+  if (!Number.isInteger(tournamentId)) {
+    return <Notice>That round id is not valid.</Notice>;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="container-page flex items-center gap-2 py-24 text-sm text-white/40">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading round…
+      </div>
+    );
+  }
+
+  if (error || !tournament) {
+    const notFound = error instanceof ApiError && error.status === 404;
+    return (
+      <Notice tone={notFound ? "muted" : "error"}>
+        {notFound
+          ? "That round does not exist."
+          : error instanceof ApiError
+            ? error.message
+            : "Failed to load this round."}
+      </Notice>
+    );
+  }
+
+  // A round's own `submission_close_at` is not stamped until it actually
+  // locks, so while the window is open the dataset endpoint is the only
+  // source of the close instant. Guarded on tournament_id so a stale cached
+  // config from a previous round can never be shown as this round's deadline.
+  const closeAt =
+    tournament.submission_close_at ??
+    (dataset?.tournament_id === tournament.id ? dataset.submission_close_at : null);
+
+  return (
+    <div className="container-page py-16 sm:py-20">
+      <Link
+        to="/tournaments"
+        className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.2em] text-white/40 transition-colors hover:text-white/70"
+      >
+        <ArrowLeft size={13} strokeWidth={1.75} />
+        All rounds
+      </Link>
+
+      <header className="mt-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <StatusBadge status={String(tournament.status)} />
+          <span className="font-mono text-[11px] text-white/35">
+            {tournament.dataset_version} · era {tournament.target_era} ·{" "}
+            {tournament.horizon_minutes}m horizon
+          </span>
+        </div>
+        <h1 className="mt-4 font-display text-3xl leading-[1.1] tracking-tight text-white sm:text-4xl">
+          {tournament.tournament_name}
+        </h1>
+      </header>
+
+      <WindowPanel tournament={tournament} closeAt={closeAt} dataset={dataset} />
+
+      <SubmitPanel tournament={tournament} closeAt={closeAt} />
+    </div>
+  );
+}
+
+function WindowPanel({
+  tournament,
+  closeAt,
+  dataset,
+}: {
+  tournament: Tournament;
+  closeAt: string | null;
+  dataset: CurrentDataset | undefined;
+}) {
+  const isOpen = tournament.status === "SUBMISSION_OPEN";
+  const isScored = tournament.status === "SCORED" || tournament.status === "COMPLETE";
+
+  return (
+    <div className="mt-10 rounded-2xl border border-white/[0.07] bg-white/[0.015] p-6 sm:p-8">
+      <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/40">
+        {isOpen ? "Submissions lock in" : isScored ? "Round scored" : "Submission window"}
+      </div>
+
+      <div className="mt-5">
+        {isOpen ? (
+          <Countdown target={closeAt} elapsedLabel="Lock imminent" />
+        ) : (
+          <p className="text-sm text-white/55">
+            {tournament.status === "LOCKED"
+              ? "Locked — scoring runs one prediction horizon after the lock."
+              : isScored
+                ? "Results for this round are published."
+                : "This round has not opened for submissions yet."}
+          </p>
+        )}
+      </div>
+
+      {dataset?.tournament_id === tournament.id && (
+        <dl className="mt-8 grid gap-6 border-t border-white/[0.06] pt-6 sm:grid-cols-3">
+          <Stat label="Ids in era" value={String(dataset.id_universe.length)} />
+          <Stat label="Feature columns" value={String(dataset.feature_columns.length)} />
+          <Stat label="Dataset rows" value={dataset.row_count.toLocaleString()} />
+        </dl>
+      )}
+
+      {isScored && (
+        <div className="mt-8 border-t border-white/[0.06] pt-6">
+          <Link
+            to="/leaderboard"
+            search={{ tournament: tournament.id }}
+            className="font-mono text-[11px] uppercase tracking-[0.2em] text-white/50 transition-colors hover:text-white"
+          >
+            View published standings →
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/35">{label}</dt>
+      <dd className="mt-2 font-mono text-lg tabular-nums text-white">{value}</dd>
+    </div>
+  );
+}
+
+function SubmitPanel({ tournament, closeAt }: { tournament: Tournament; closeAt: string | null }) {
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const now = useNow();
+
+  // The server is the authority on the window (it re-checks status AND the
+  // close timestamp on every upload). This disable exists so the UI does not
+  // invite a submission it already knows will be rejected — it is never the
+  // thing that actually enforces the deadline.
+  const closeMs = closeAt ? new Date(closeAt).getTime() : null;
+  const windowOpen = tournament.status === "SUBMISSION_OPEN" && (closeMs === null || closeMs > now);
+
+  const mutation = useMutation<SubmissionResponse, unknown, File>({
+    mutationFn: (f) => submissionsApi.submit(tournament.id, f, f.name),
+    onSuccess: () => {
+      setFile(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      queryClient.invalidateQueries({ queryKey: ["tournament", tournament.id] });
+    },
+  });
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLocalError(null);
+    mutation.reset();
+    // Presence and emptiness only. Column, id-universe and score-range checks
+    // belong to the server's validator (Frontend/CLAUDE.md §7) — duplicating
+    // them here would make the browser a second, drifting source of truth.
+    if (!file) {
+      setLocalError("Choose a CSV file to submit.");
+      return;
+    }
+    if (file.size === 0) {
+      setLocalError("That file is empty.");
+      return;
+    }
+    mutation.mutate(file);
+  }
+
+  return (
+    <div className="mt-6 rounded-2xl border border-white/[0.07] bg-white/[0.015] p-6 sm:p-8">
+      <div className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/40">
+        Submit predictions
+      </div>
+
+      <ul className="mt-5 space-y-1.5 text-sm leading-relaxed text-white/55">
+        <li>
+          CSV with exactly two columns: <code className="font-mono text-white/75">id</code> and{" "}
+          <code className="font-mono text-white/75">score</code>.
+        </li>
+        <li>
+          Every <code className="font-mono text-white/75">id</code> in this round&rsquo;s era
+          universe must appear exactly once — no extras, no duplicates, no blanks.
+        </li>
+        <li>
+          <code className="font-mono text-white/75">score</code> is a signed confidence in{" "}
+          <span className="font-mono text-white/75">[-1, 1]</span>: the sign is your predicted
+          direction, the magnitude your conviction.
+        </li>
+      </ul>
+
+      <form onSubmit={onSubmit} className="mt-7">
+        <input
+          ref={fileInputRef}
+          id="predictions"
+          type="file"
+          accept=".csv,text/csv"
+          disabled={!windowOpen || mutation.isPending}
+          onChange={(e) => {
+            setFile(e.target.files?.[0] ?? null);
+            setLocalError(null);
+            mutation.reset();
+          }}
+          className="block w-full cursor-pointer rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3 text-sm text-white/70 transition-colors file:mr-4 file:rounded-full file:border-0 file:bg-white/10 file:px-4 file:py-1.5 file:text-xs file:text-white hover:border-white/20 disabled:cursor-not-allowed disabled:opacity-40"
+        />
+
+        <div className="mt-5 flex flex-wrap items-center gap-4">
+          <Button type="submit" disabled={!windowOpen || mutation.isPending} withArrow>
+            {mutation.isPending ? "Uploading…" : "Upload submission"}
+          </Button>
+          {!windowOpen && (
+            <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-white/40">
+              <Upload size={12} strokeWidth={1.75} />
+              {tournament.status === "SUBMISSION_OPEN"
+                ? "Window closed — waiting for the lock"
+                : "This round is not accepting submissions"}
+            </span>
+          )}
+        </div>
+      </form>
+
+      {localError && (
+        <p className="mt-5 rounded-lg border border-[#ff8a8a]/30 bg-[#ff8a8a]/10 px-3 py-2 text-xs text-[#ff8a8a]">
+          {localError}
+        </p>
+      )}
+
+      {mutation.error != null && <RejectionNotice error={mutation.error} />}
+
+      {mutation.isSuccess && mutation.data && <AcceptedNotice submission={mutation.data} />}
+    </div>
+  );
+}
+
+// A rejected CSV is the moment a researcher most needs specifics: Backend
+// answers 422 with a list of {field, error} objects, one per rule broken, and
+// each is surfaced verbatim rather than collapsed into "invalid file".
+function RejectionNotice({ error }: { error: unknown }) {
+  const rules = validationRules(error);
+
+  return (
+    <div className="mt-5 rounded-xl border border-[#ff8a8a]/25 bg-[#ff8a8a]/[0.06] px-5 py-4 text-sm text-[#ffb4b4]">
+      <p className="font-medium">Submission rejected.</p>
+      {rules ? (
+        <ul className="mt-3 space-y-2">
+          {rules.map((r, i) => (
+            <li key={i} className="flex flex-wrap gap-x-2 text-xs leading-relaxed">
+              <span className="font-mono uppercase tracking-[0.16em] text-[#ffb4b4]/60">
+                {r.field}
+              </span>
+              <span className="flex-1 min-w-[12rem]">{r.error}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-2 text-xs">
+          {error instanceof ApiError ? error.message : "Could not reach the server."}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function validationRules(error: unknown): { field: string; error: string }[] | null {
+  if (!(error instanceof ApiError)) return null;
+  const detail = error.detail;
+  if (!detail || typeof detail !== "object" || !("errors" in detail)) return null;
+  const raw = (detail as { errors: unknown }).errors;
+  if (!Array.isArray(raw)) return null;
+  return raw.map((e) =>
+    e && typeof e === "object"
+      ? {
+          field: String((e as Record<string, unknown>).field ?? "file"),
+          error: String((e as Record<string, unknown>).error ?? ""),
+        }
+      : { field: "file", error: String(e) },
+  );
+}
+
+function AcceptedNotice({ submission }: { submission: SubmissionResponse }) {
+  return (
+    <div className="mt-5 rounded-xl border border-emerald-400/25 bg-emerald-400/[0.06] px-5 py-4 text-sm text-emerald-200">
+      <p className="inline-flex items-center gap-2 font-medium">
+        <CheckCircle2 size={15} strokeWidth={1.75} />
+        Submission accepted.
+      </p>
+      <p className="mt-2 font-mono text-[11px] text-emerald-200/70">
+        #{submission.id} · {submission.row_count.toLocaleString()} rows ·{" "}
+        {submission.file_hash.slice(0, 12)}
+      </p>
+    </div>
+  );
+}
+
+function Notice({ children, tone = "muted" }: { children: ReactNode; tone?: "muted" | "error" }) {
+  return (
+    <div className="container-page py-24">
+      <div
+        className={
+          tone === "error"
+            ? "rounded-xl border border-[#ff8a8a]/25 bg-[#ff8a8a]/[0.06] px-5 py-4 text-sm text-[#ffb4b4]"
+            : "rounded-xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center text-sm text-white/45"
+        }
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/routes/tournaments/$tournamentId.tsx
+++ b/src/routes/tournaments/$tournamentId.tsx
@@ -8,6 +8,7 @@ import { RequireAuth } from "@/components/site/RequireAuth";
 import { Countdown } from "@/components/site/Countdown";
 import { Button } from "@/components/site/Button";
 import { useNow } from "@/hooks/use-now";
+import { parseServerTime } from "@/lib/time";
 import {
   ApiError,
   datasetsApi,
@@ -200,7 +201,11 @@ function SubmitPanel({ tournament, closeAt }: { tournament: Tournament; closeAt:
   // close timestamp on every upload). This disable exists so the UI does not
   // invite a submission it already knows will be rejected — it is never the
   // thing that actually enforces the deadline.
-  const closeMs = closeAt ? new Date(closeAt).getTime() : null;
+  // parseServerTime, not `new Date(...)`: Backend serializes naive UTC with no
+  // offset, which ECMAScript would otherwise read as the viewer's local time.
+  // At +05:30 that put the close instant 5.5h in the past and disabled this
+  // form for the whole window, for a file the server would have accepted.
+  const closeMs = parseServerTime(closeAt);
   const windowOpen = tournament.status === "SUBMISSION_OPEN" && (closeMs === null || closeMs > now);
 
   const mutation = useMutation<SubmissionResponse, unknown, File>({

--- a/src/routes/tournaments/index.tsx
+++ b/src/routes/tournaments/index.tsx
@@ -1,0 +1,133 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowUpRight, Loader2, Trophy } from "lucide-react";
+
+import { AppShell, StatusBadge } from "@/components/site/AppShell";
+import { RequireAuth } from "@/components/site/RequireAuth";
+import { CountdownChip } from "@/components/site/Countdown";
+import { tournamentsApi, ApiError, type Tournament } from "@/lib/api";
+
+export const Route = createFileRoute("/tournaments/")({
+  head: () => ({
+    meta: [
+      { title: "Tournaments — IndiQuant" },
+      { name: "description", content: "Active research tournaments and their submission windows." },
+      { name: "robots", content: "noindex" },
+    ],
+  }),
+  component: TournamentsPage,
+});
+
+function TournamentsPage() {
+  return (
+    <AppShell>
+      <RequireAuth redirectTo="/tournaments">
+        <TournamentsList />
+      </RequireAuth>
+    </AppShell>
+  );
+}
+
+function TournamentsList() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["tournaments"],
+    queryFn: () => tournamentsApi.list(),
+    refetchInterval: 60_000, // 1h cadence — a light refresh keeps windows current
+  });
+
+  return (
+    <div className="container-page py-16 sm:py-20">
+      <header className="mb-10 max-w-2xl">
+        <div className="inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.2em] text-white/45">
+          <Trophy size={13} strokeWidth={1.75} />
+          Tournaments
+        </div>
+        <h1 className="mt-4 font-display text-4xl leading-[1.05] tracking-tight text-white sm:text-5xl">
+          Research rounds
+        </h1>
+        <p className="mt-4 text-sm leading-relaxed text-white/55">
+          Predict relative returns on an anonymized universe of Indian equities. Submissions
+          run on a 1-hour cadence — each round locks, then scores one horizon later.
+        </p>
+      </header>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 py-16 text-sm text-white/40">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading tournaments…
+        </div>
+      )}
+
+      {error && !isLoading && (
+        <div className="rounded-xl border border-[#ff8a8a]/25 bg-[#ff8a8a]/[0.06] px-5 py-4 text-sm text-[#ffb4b4]">
+          {error instanceof ApiError ? error.message : "Failed to load tournaments."}
+        </div>
+      )}
+
+      {!isLoading && !error && data && data.length === 0 && (
+        <div className="rounded-xl border border-white/10 bg-white/[0.02] px-5 py-10 text-center text-sm text-white/45">
+          No tournaments are open right now. Check back soon.
+        </div>
+      )}
+
+      {!isLoading && !error && data && data.length > 0 && (
+        <ul className="grid gap-4">
+          {data.map((t) => (
+            <TournamentRow key={t.id} tournament={t} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function TournamentRow({ tournament: t }: { tournament: Tournament }) {
+  const isOpen = t.status === "SUBMISSION_OPEN";
+  const isScored = t.status === "SCORED" || t.status === "COMPLETE";
+
+  return (
+    <li>
+      <Link
+        to="/tournaments/$tournamentId"
+        params={{ tournamentId: String(t.id) }}
+        className="group block rounded-2xl border border-white/[0.07] bg-white/[0.015] p-6 transition-all duration-300 hover:-translate-y-0.5 hover:border-white/20 hover:bg-white/[0.03]"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-3">
+              <StatusBadge status={String(t.status)} />
+              <span className="font-mono text-[11px] text-white/35">
+                {t.dataset_version} · era {t.target_era}
+              </span>
+            </div>
+            <h2 className="mt-3 truncate text-lg font-medium tracking-tight text-white">
+              {t.tournament_name}
+            </h2>
+          </div>
+          <ArrowUpRight
+            size={18}
+            strokeWidth={1.5}
+            className="mt-1 shrink-0 text-white/30 transition-all duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-white/70"
+          />
+        </div>
+
+        <div className="mt-5 flex flex-wrap items-center gap-2.5">
+          {isOpen ? (
+            <CountdownChip target={t.submission_close_at} prefix="Locks in" elapsedLabel="lock imminent" />
+          ) : isScored ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-sky-400/25 bg-sky-400/[0.08] px-3 py-1 font-mono text-[11px] text-sky-200">
+              Results available
+            </span>
+          ) : t.status === "LOCKED" ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-400/25 bg-amber-400/[0.08] px-3 py-1 font-mono text-[11px] text-amber-200">
+              Locked · scoring
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 font-mono text-[11px] text-white/45">
+              Not yet open
+            </span>
+          )}
+        </div>
+      </Link>
+    </li>
+  );
+}


### PR DESCRIPTION
Rolls up this session's work: the 7-stage pipeline build, two strictness waves replacing permissive defaults on missing risk inputs with real failures, and the fixes found by running the loop end to end for the first time.

**Verified end to end before this PR** — v0.2 hourly dataset built (712,116 rows, 98 ids, 7,279 eras, signed [-1,1] target) → tournament created → dataset pulled through the real `indiquant-data` client → predictions submitted → locked → scored → public leaderboard served unauthenticated → meta-model selection → Portfolio-Engine construction → signed weights accepted by Experiment-Registry's real consumer.

**Guardrails asserted, not assumed:** the served parquet carries no `target` and no identity column; the public leaderboard returns no email and no `user_id`; an unsigned weights forgery is refused.

**Known and recorded, not hidden:** the v0.2 universe is the NSE200-liquidity proxy, not the NIFTY 100 — 67 of 98 symbols are index members. The manifest says so (`universe_source: nse200_liquidity_proxy`, `proxy_universe_override: true`) and names every non-constituent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)